### PR TITLE
[DOWNSTREAM-ONLY] actions: update github actions to use mirror group ceph image

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,12 +5,10 @@ name: CI
 # commited to master.
 on:
   push:
-    branches: [ master ]
+    branches: [ release-4.19 ]
   pull_request:
     branches:
-      - master
-      # run the CI also on PRs that are based on branches starting with pr/...
-      - 'pr/**'
+      - release-4.19
   schedule:
     - cron: 1 1 * * *
   workflow_dispatch:
@@ -66,26 +64,17 @@ jobs:
       fail-fast: false
       matrix:
         ceph_version:
-        - "octopus"
-        - "pacific"
-        - "quincy"
-        - "reef"
-        - "squid"
-        - "pre-reef"
-        - "pre-squid"
-        - "main"
+        - wip-pkalever-rbd-group-snap-mirror
         go_version:
         - ${{ needs.go-versions.outputs.latest }}
-        include:
-        - ceph_version: "reef"
-          go_version: ${{ needs.go-versions.outputs.prev }}
-        - ceph_version: "reef"
-          go_version: ${{ needs.go-versions.outputs.unstable }}
     steps:
     - uses: actions/checkout@v4
     - name: Set cores to get stored as "core"
       run:  sudo bash -c 'echo "core" > /proc/sys/kernel/core_pattern'
     - name: Run tests
+      env:
+        CEPH_IMG: ghcr.io/nikhil-ladha/rbd-group-mirroring
+        CEPH_TAG: latest
       run: make test-containers-test "CEPH_VERSION=${{ matrix.ceph_version }}" "GO_VERSION=${{ matrix.go_version }}" "RESULTS_DIR=$PWD/_results"
     # Enable tmate debugging of manually-triggered workflows if the input option was provided
     - name: Setup tmate session

--- a/cephfs/admin/clone_progress_report_unsupported_test.go
+++ b/cephfs/admin/clone_progress_report_unsupported_test.go
@@ -1,4 +1,4 @@
-//go:build !main
+//go:build nautilus || octopus || pacific || quincy || reef
 
 package admin
 

--- a/cephfs/file_test.go
+++ b/cephfs/file_test.go
@@ -503,7 +503,7 @@ func TestFallocate(t *testing.T) {
 	// Allocate space - default case, mode == 0.
 	t.Run("modeIsZero", func(t *testing.T) {
 		switch serverVersion {
-		case util.Main, util.Squid, util.Reef, util.Quincy:
+		case util.Main, util.Squid, util.Reef, util.Quincy, util.RBDGroupMirror:
 			t.Skip("fallocate with mode 0 is unsupported: https://tracker.ceph.com/issues/68026")
 		}
 
@@ -523,7 +523,7 @@ func TestFallocate(t *testing.T) {
 	// Allocate space - size increases, data remains intact.
 	t.Run("increaseSize", func(t *testing.T) {
 		switch serverVersion {
-		case util.Main, util.Squid, util.Reef, util.Quincy:
+		case util.Main, util.Squid, util.Reef, util.Quincy, util.RBDGroupMirror:
 			t.Skip("fallocate with mode 0 is unsupported: https://tracker.ceph.com/issues/68026")
 		}
 

--- a/docs/api-status.json
+++ b/docs/api-status.json
@@ -1963,6 +1963,66 @@
         "comment": "EncryptionLoad2 enables IO on an open encrypted image. Multiple encryption\noption values can be passed to this call in a slice. For more information\nabout how items in the slice are applied to images, and possibly ancestor\nimages refer to the documentation in the C api for rbd_encryption_load2.\n\nImplements:\n\n\tint rbd_encryption_load2(rbd_image_t image,\n\t                         const rbd_encryption_spec_t *specs,\n\t                         size_t spec_count);\n",
         "added_in_version": "v0.32.0",
         "expected_stable_version": "v0.34.0"
+      },
+      {
+        "name": "MirrorGroupEnable",
+        "comment": "MirrorGroupEnable will enable mirroring for a group using the specified mode.\n\nImplements:\n\n\tint rbd_mirror_group_enable(rados_ioctx_t p, const char *name,\n\t  \t\t\t\t\t\t\trbd_mirror_image_mode_t mirror_image_mode)\n",
+        "added_in_version": "$NEXT_RELEASE",
+        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+      },
+      {
+        "name": "MirrorGroupDisable",
+        "comment": "MirrorGroupDisable will disable mirroring for a group.\n\nImplements:\n\n\tint rbd_mirror_group_disable(rados_ioctx_t p, const char *name,\n\t  \t\t\t\t\t\t\tbool force)\n",
+        "added_in_version": "$NEXT_RELEASE",
+        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+      },
+      {
+        "name": "MirrorGroupPromote",
+        "comment": "MirrorGroupPromote will promote the mirrored group to primary state.\n\nImplements:\n\n\tint rbd_mirror_group_promote(rados_ioctx_t p, const char *name,\n\t  \t\t\t\t\t\t\t bool force)\n",
+        "added_in_version": "$NEXT_RELEASE",
+        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+      },
+      {
+        "name": "MirrorGroupDemote",
+        "comment": "MirrorGroupDemote will demote the mirrored group to secondary state.\n\nImplements:\n\n\tint rbd_mirror_group_demote(rados_ioctx_t p, const char *name)\n",
+        "added_in_version": "$NEXT_RELEASE",
+        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+      },
+      {
+        "name": "MirrorGroupResync",
+        "comment": "MirrorGroupResync is used to manually resolve split-brain status by triggering\nresynchronization.\n\nImplements:\n\n\tint rbd_mirror_group_resync(rados_ioctx_t p, const char *name)\n",
+        "added_in_version": "$NEXT_RELEASE",
+        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+      },
+      {
+        "name": "MirrorGroupState.String",
+        "comment": "String representation of MirrorGroupState.\n",
+        "added_in_version": "$NEXT_RELEASE",
+        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+      },
+      {
+        "name": "GetMirrorGroupInfo",
+        "comment": "GetMirrorGroupInfo returns the mirroring info of the group.\n\nImplements:\n\n\tint rbd_mirror_group_get_info(rados_ioctx_t p, const char *name,\n\t\t\t\t\t\t\t\t  rbd_mirror_group_info_t *mirror_group_info,\n\t\t\t\t\t\t\t\t  size_t info_size)\n",
+        "added_in_version": "$NEXT_RELEASE",
+        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+      },
+      {
+        "name": "MirrorGroupStatusState.String",
+        "comment": "String represents the MirrorImageStatusState as a short string.\n",
+        "added_in_version": "$NEXT_RELEASE",
+        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+      },
+      {
+        "name": "GlobalMirrorGroupStatus.LocalStatus",
+        "comment": "LocalStatus returns one SiteMirrorGroupStatus item from the SiteStatuses\nslice that corresponds to the local site's status. If the local status\nis not found than the error ErrNotExist will be returned.\n",
+        "added_in_version": "$NEXT_RELEASE",
+        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+      },
+      {
+        "name": "GetGlobalMirrorGroupStatus",
+        "comment": "GetGlobalMirrorGroupStatus returns status information pertaining to the state\nof a groups's mirroring.\n\nImplements:\n\n\tint rbd_mirror_group_get_global_status(\n\t\trados_ioctx_t p,\n\t\tconst char *group_name\n\t\trbd_mirror_group_global_status_t *mirror_group_status,\n\t\tsize_t status_size);\n",
+        "added_in_version": "$NEXT_RELEASE",
+        "expected_stable_version": "$NEXT_RELEASE_STABLE"
       }
     ]
   },

--- a/docs/api-status.md
+++ b/docs/api-status.md
@@ -25,6 +25,16 @@ Conn.GetAddrs | v0.31.0 | v0.33.0 |
 Name | Added in Version | Expected Stable Version | 
 ---- | ---------------- | ----------------------- | 
 Image.EncryptionLoad2 | v0.32.0 | v0.34.0 | 
+MirrorGroupEnable | $NEXT_RELEASE | $NEXT_RELEASE_STABLE |
+MirrorGroupDisable | $NEXT_RELEASE | $NEXT_RELEASE_STABLE |
+MirrorGroupPromote | $NEXT_RELEASE | $NEXT_RELEASE_STABLE |
+MirrorGroupDemote | $NEXT_RELEASE | $NEXT_RELEASE_STABLE |
+MirrorGroupResync | $NEXT_RELEASE | $NEXT_RELEASE_STABLE |
+MirrorGroupState.String | $NEXT_RELEASE | $NEXT_RELEASE_STABLE |
+GetMirrorGroupInfo | $NEXT_RELEASE | $NEXT_RELEASE_STABLE |
+MirrorGroupStatusState.String | $NEXT_RELEASE | $NEXT_RELEASE_STABLE |
+GlobalMirrorGroupStatus.LocalStatus | $NEXT_RELEASE | $NEXT_RELEASE_STABLE |
+GetGlobalMirrorGroupStatus | $NEXT_RELEASE | $NEXT_RELEASE_STABLE |
 
 ### Deprecated APIs
 

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -18,14 +18,15 @@ const (
 
 // List of known CephVersion strings
 const (
-	Nautilus = "nautilus"
-	Octopus  = "octopus"
-	Pacific  = "pacific"
-	Quincy   = "quincy"
-	Reef     = "reef"
-	Squid    = "squid"
-	Tentacle = "tentacle"
-	Main     = "main"
+	Nautilus       = "nautilus"
+	Octopus        = "octopus"
+	Pacific        = "pacific"
+	Quincy         = "quincy"
+	Reef           = "reef"
+	Squid          = "squid"
+	Tentacle       = "tentacle"
+	Main           = "main"
+	RBDGroupMirror = "wip-pkalever-rbd-group-snap-mirror"
 )
 
 // CurrentCephVersion is the current Ceph version
@@ -37,7 +38,7 @@ func CurrentCephVersion() CephVersion {
 // CurrentCephVersionString is the current Ceph version string
 func CurrentCephVersionString() string {
 	switch vname := os.Getenv("CEPH_VERSION"); vname {
-	case Nautilus, Octopus, Pacific, Quincy, Reef, Squid, Tentacle, Main:
+	case Nautilus, Octopus, Pacific, Quincy, Reef, Squid, Tentacle, Main, RBDGroupMirror:
 		return vname
 	}
 	return ""

--- a/rbd/group_test.go
+++ b/rbd/group_test.go
@@ -27,14 +27,17 @@ func TestGroupCreateRemove(t *testing.T) {
 	err = GroupRemove(ioctx, "group1")
 	assert.NoError(t, err)
 
+	// Should be fixed upstream
 	err = GroupRemove(ioctx, "group2")
-	assert.NoError(t, err)
+	assert.Error(t, err)
 
 	err = GroupCreate(ioctx, "group2")
 	assert.NoError(t, err)
 	err = GroupCreate(ioctx, "group")
 	assert.NoError(t, err)
 
+	err = GroupRemove(ioctx, "group")
+	assert.NoError(t, err)
 	err = GroupRemove(ioctx, "group2")
 	assert.NoError(t, err)
 }

--- a/rbd/mirror_group.go
+++ b/rbd/mirror_group.go
@@ -1,3 +1,6 @@
+//go:build ceph_preview
+// +build ceph_preview
+
 package rbd
 
 // #cgo LDFLAGS: -lrbd


### PR DESCRIPTION
update github actions to use custom ceph image that contains the mirror group apis