### PR TITLE
[DOWNSTREAM ONLY] ci: disable dependabot PR creation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,8 @@
 version: 2
 updates:
   - package-ecosystem: "gomod"
+    # ODF only: disable PR creation, synced from upstream
+    open-pull-requests-limit: 0
     directory: "/"
     schedule:
       interval: "monthly"
@@ -15,6 +17,8 @@ updates:
         patterns:
           - "github.com/aws/aws-sdk-*"
   - package-ecosystem: "gomod"
+    # ODF only: disable PR creation, synced from upstream
+    open-pull-requests-limit: 0
     directory: "/contrib/implements"
     schedule:
       interval: "monthly"
@@ -24,6 +28,8 @@ updates:
     commit-message:
       prefix: "contrib"
   - package-ecosystem: "github-actions"
+    # ODF only: disable PR creation, synced from upstream
+    open-pull-requests-limit: 0
     directory: "/"
     schedule:
       interval: "monthly"


### PR DESCRIPTION
Dependabot does not need to report available updates for vendored dependencies in the downstream repository. Updates to dependencies are synced from the upstream repository when needed. There is also the "Upstream First" requirement, which we follow closely.

See-also: https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates#open-pull-requests-limit

/cc Nikhil-Ladha