### PR TITLE
[release-4.19] Bump go (stdlib: net/http) from 1.22 to 1.22.2

### DIFF
--- a/contrib/implements/go.mod
+++ b/contrib/implements/go.mod
@@ -1,6 +1,6 @@
 module implements
 
-go 1.21
+go 1.21.9
 
 require modernc.org/cc/v4 v4.26.2
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ceph/go-ceph
 
-go 1.22
+go 1.22.2
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.36.3


### PR DESCRIPTION
### Changes
- **go (stdlib: net/http)**: `1.21` → `1.21.9` (in `contrib/implements/go.mod`)
- **go (stdlib: net/http)**: `1.22` → `1.22.2` (in `go.mod`)
