### PR TITLE
[release-4.20] Bump go (stdlib: net/http) from 1.21 to 1.21.9

### DIFF
--- a/contrib/implements/go.mod
+++ b/contrib/implements/go.mod
@@ -1,6 +1,6 @@
 module implements
 
-go 1.21
+go 1.21.9
 
 require modernc.org/cc/v4 v4.26.2
 


### PR DESCRIPTION
### Changes
- **go (stdlib: net/http)**: `1.21` → `1.21.9` (in `contrib/implements/go.mod`)
