### PR TITLE
[release-4.22] Bump go (stdlib) from 1.21 to 1.24.2

### DIFF
--- a/contrib/implements/go.mod
+++ b/contrib/implements/go.mod
@@ -1,6 +1,6 @@
 module implements
 
-go 1.21
+go 1.24.2
 
 require modernc.org/cc/v4 v4.27.1
 


### PR DESCRIPTION
### Changes
- **go (stdlib)**: `1.21` → `1.24.2` (in `contrib/implements/go.mod`)
