### PR TITLE
[release-4.22] Bump go (stdlib) from 1.21 to 1.25.5

### DIFF
--- a/contrib/implements/go.mod
+++ b/contrib/implements/go.mod
@@ -1,6 +1,6 @@
 module implements
 
-go 1.21
+go 1.25.5
 
 require modernc.org/cc/v4 v4.27.1
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ceph/go-ceph
 
-go 1.25.0
+go 1.25.5
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.41.2


### PR DESCRIPTION
### Changes
- **go (stdlib)**: `1.21` → `1.25.5` (in `contrib/implements/go.mod`)
- **go (stdlib)**: `1.25.0` → `1.25.5` (in `go.mod`)
